### PR TITLE
better error messages when parsing.

### DIFF
--- a/Data/OpenRecords/Aeson.hs
+++ b/Data/OpenRecords/Aeson.hs
@@ -2,12 +2,16 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 
 module Data.OpenRecords.Aeson where
 
 import Data.Aeson
 import Data.Aeson.Types (typeMismatch)
 import qualified Data.HashMap.Lazy as M
+import Data.List (intercalate)
 import Data.OpenRecords
 import Data.Proxy
 import Data.Text (Text)
@@ -17,10 +21,15 @@ instance Forall r ToJSON => ToJSON (Rec r) where
     toJSON = Object . eraseToHashMap (Proxy @ToJSON) toJSON
 
 instance Forall r FromJSON => FromJSON (Rec r) where
-    parseJSON (Object o) = rinitAWithLabel (Proxy @FromJSON) $ \ l -> case M.lookup (show' l) o of
-        Nothing -> typeMismatch "" (Object o)
-        Just v -> parseJSON v
-    parseJSON v = typeMismatch "" v
+    parseJSON (Object o) = rinitAWithLabel (Proxy @FromJSON) $ \ l -> o .: (show' l)
+    parseJSON v = typeMismatch msg v
+      where
+        msg = "{" ++ intercalate "," fields ++ "}"
+        fields = labels @r @FromJSON $ rinit (Proxy @FromJSON) undefined
 
 show' :: Show a => a -> Text
 show' = Text.pack . show
+
+-- DUPLICATED because @Data.OpenRecords@ does not export it.
+labels :: forall r c. Forall r c => Rec r -> [String]
+labels = fmap fst . eraseWithLabels (Proxy @c) (\ _ -> undefined)


### PR DESCRIPTION
Previously error messages for missing fields looked like

```
Error while parsing ... expected , got Object
```

now they should look like:

```
Error while parsing ... expected field-name, got Object
```